### PR TITLE
Fixes #8 '6 arguments instead of 4' error

### DIFF
--- a/lib/ResqueScheduler.php
+++ b/lib/ResqueScheduler.php
@@ -223,7 +223,7 @@ class ResqueScheduler
 			$at = self::getTimestamp($at);
 		}
 	
-		$items = Resque::redis()->zrangebyscore('delayed_queue_schedule', '-inf', $at, 'LIMIT', 0, 1);
+		$items = Resque::redis()->zrangebyscore('delayed_queue_schedule', '-inf', $at, array('limit' => array(0, 1)));
 		if (!empty($items)) {
 			return $items[0];
 		}


### PR DESCRIPTION
I'm not sure if this happens to be implemented for an old version of Redis (php module), but this works for the latest version.
