### PR TITLE
Added ResqueScheduler::VERSION constant

### DIFF
--- a/lib/ResqueScheduler.php
+++ b/lib/ResqueScheduler.php
@@ -9,6 +9,8 @@
 */
 class ResqueScheduler
 {
+	const VERSION = "0.1";
+	
 	/**
 	 * Enqueue a job in a given number of seconds from now.
 	 *


### PR DESCRIPTION
This fixes the error thrown when trying to set the proctitle if the constant doesn't exist.

Signed-off-by: Daniel Hunsaker danhunsaker@gmail.com
