### PR TITLE
Errors/Issues - Credis + Scheduling in Prod Envs

### DIFF
--- a/lib/ResqueScheduler.php
+++ b/lib/ResqueScheduler.php
@@ -225,7 +225,7 @@ class ResqueScheduler
 			$at = self::getTimestamp($at);
 		}
 	
-		$items = Resque::redis()->zrangebyscore('delayed_queue_schedule', '-inf', $at, array('limit' => array(0, 1)));
+		$items = Resque::redis()->zrangebyscore('delayed_queue_schedule', '-inf', $at, 'limit' ,0, 1);
 		if (!empty($items)) {
 			return $items[0];
 		}

--- a/lib/ResqueScheduler/Worker.php
+++ b/lib/ResqueScheduler/Worker.php
@@ -84,6 +84,7 @@ class ResqueScheduler_Worker
 			$payload = array_merge(array($item['queue'], $item['class']), $item['args']);
 			call_user_func_array('Resque::enqueue', $payload);
 		}
+		Resque::$redis = null;
 	}
 	
 	/**


### PR DESCRIPTION
Fixing issues with credis. Expecting string but getting array. Modified to return string.

In production environments, resque scheduler stops working due to issue with redis connection. This fixes the problem by resetting the connection.