### PR TITLE
bugfix in timestamp allocation for scheduler worker

### DIFF
--- a/lib/ResqueScheduler/Worker.php
+++ b/lib/ResqueScheduler/Worker.php
@@ -55,7 +55,7 @@ class ResqueScheduler_Worker
 	 */
 	public function handleDelayedItems($timestamp = null)
 	{
-		while (($timestamp = ResqueScheduler::nextDelayedTimestamp($timestamp)) !== false) {
+		while ((ResqueScheduler::nextDelayedTimestamp($timestamp)) !== false) {
 			$this->updateProcLine('Processing Delayed Items');
 			$this->enqueueDelayedItemsForTimestamp($timestamp);
 		}


### PR DESCRIPTION
- fixed bug: if there are more than 1 items to be processed with different timestamps in the past, then the scheduler will sleep() before it picks up the next item in the past. If messages keep on being queued faster then 1 per second then eventually the scheduler cannot keep up