### PR TITLE
Fix bug where scheduler sleeps when processing a delayed queue

### DIFF
--- a/lib/ResqueScheduler/Worker.php
+++ b/lib/ResqueScheduler/Worker.php
@@ -55,9 +55,9 @@ class ResqueScheduler_Worker
 	 */
 	public function handleDelayedItems($timestamp = null)
 	{
-		while (($timestamp = ResqueScheduler::nextDelayedTimestamp($timestamp)) !== false) {
+		while (($oldestJobTimestamp = ResqueScheduler::nextDelayedTimestamp($timestamp)) !== false) {
 			$this->updateProcLine('Processing Delayed Items');
-			$this->enqueueDelayedItemsForTimestamp($timestamp);
+			$this->enqueueDelayedItemsForTimestamp($oldestJobTimestamp);
 		}
 	}
 	


### PR DESCRIPTION
The function handleDelayedItems() was overwriting the parameter
$timestamp from the call nextDelayedTimestamp() with timestamp of
the most delayed job. Therefor it would only process 1 seconds
worth of items before sleeping. A slighty delayed queue could
fall very far behind.