### PR TITLE
Make compatible with the newest version of resque/php-resque

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,8 @@
     },
     "require": {
         "resque/php-resque": "~1.3.3"
-    }
+    },
+    "bin": [
+        "resque-scheduler"
+    ]
 }

--- a/composer.json
+++ b/composer.json
@@ -1,23 +1,20 @@
 {
-	"name": "chrisboulton/php-resque-scheduler",
-	"type": "library",
-	"description": "php-resque-scheduler is a PHP port of resque-scheduler, which adds support for scheduling items in the future to Resque.",
-	"license": "MIT",
-	"authors": [
-		{
-			"name": "Chris Boulton",
-			"email": "chris@bgigcommerce.com"
-		}
-	],
-	"autoload": {
-		"psr-0": {
-			"ResqueScheduler": "lib/"
-		}
-	},
-	"repositories": [
-		{ "type": "git", "url": "https://github.com/chrisboulton/php-resque" }
-	],
-	"require": {
-		"chrisboulton/php-resque": "dev-master"
-	}
+    "name": "chrisboulton/php-resque-scheduler",
+    "description": "php-resque-scheduler is a PHP port of resque-scheduler, which adds support for scheduling items in the future to Resque.",
+    "license": "MIT",
+    "type": "library",
+    "authors": [
+        {
+            "email": "chris@bgigcommerce.com",
+            "name": "Chris Boulton"
+        }
+    ],
+    "autoload": {
+        "psr-0": {
+            "ResqueScheduler": "lib/"
+        }
+    },
+    "require": {
+        "resque/php-resque": "~1.3.3"
+    }
 }

--- a/resque-scheduler
+++ b/resque-scheduler
@@ -1,3 +1,4 @@
+#!/usr/bin/env php
 <?php
 
 require_once 'vendor/autoload.php';

--- a/resque-scheduler.php
+++ b/resque-scheduler.php
@@ -1,5 +1,7 @@
 <?php
 
+require_once 'vendor/autoload.php';
+
 // Look for an environment variable with 
 $RESQUE_PHP = getenv('RESQUE_PHP');
 if (!empty($RESQUE_PHP)) {


### PR DESCRIPTION
We have implemented `php-resque-scheduler` in one of our projects.

In order to set it up we had to fix some issues:
- Change `chrisboulton/php-resque` to `resque/php-resque` in the `composer.json` file.
- Require `vendor/autoload.php` in `resque-scheduler`
- Make `resque-scheduler` executable with the correct permissions